### PR TITLE
Adds a cleaned up runner script to work from outside build/repo dir

### DIFF
--- a/scripts/start_mviewer.sh
+++ b/scripts/start_mviewer.sh
@@ -1,5 +1,28 @@
 #!/bin/bash
-. mViewer.properties
-port=${1:-$WINSTONE_PORT}
-echo Using Http Port : $port
-java -jar ./winstone-0.9.10.jar --httpPort=$port --ajp13Port=-1 --warfile=./mViewer.war
+
+FILE="$BASH_SOURCE"
+if [[ "$FILE" == "" ]]; then
+    FILE="$0"
+fi
+
+SCRIPT=$(readlink -f $FILE)
+SCRIPT_DIR=$(dirname $SCRIPT)
+
+PORT=$(echo "${1:-$WINSTONE_PORT}" | grep -E ^\-?[0-9]+$)
+PROPERTIES="$SCRIPT_DIR/mViewer.properties"
+WINSTONE_JAR="$SCRIPT_DIR/winstone-0.9.10.jar"
+WAR_FILE="$SCRIPT_DIR/mViewer.war"
+
+if [[ "$PORT" == "" ]]; then
+    echo "Non-numeric port provided. Falling back to 8080"
+    PORT=8080
+fi
+
+
+if [[ -f "$PROPERTIES" ]]; then
+    echo "Sourcing properties"
+    . "$PROPERTIES"
+fi
+
+echo "Using Http Port : $PORT"
+java -jar $WINSTONE_JAR --httpPort=$PORT --ajp13Port=-1 --warfile=$WAR_FILE


### PR DESCRIPTION
1. Uses readlink/dirname to ascertain path and set corresponding paths
for Winstone JAR and mViewer WAR files.

2. Adds a numeric check on port and falls back to 8080 if non-numeric
port is provided.

3. Checks the presence of properties file before attempting to source
it.